### PR TITLE
Documentation restore after 225f70e08a3bd4521e15290c4e9f47c146e97bd4

### DIFF
--- a/log4j-transform-maven-shade-plugin-extensions/README.adoc
+++ b/log4j-transform-maven-shade-plugin-extensions/README.adoc
@@ -1,0 +1,77 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to you under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+= Log4j Plugin Cache Transformer
+
+A
+https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html[resource transformer]
+for the
+https://maven.apache.org/plugins/maven-shade-plugin/index.html[Apache Maven Shade Plugin]
+that merges `Log4j2Plugins.dat` plugin caches from all the jars containing Log4j 2.x Core components.
+
+This transformer was formerly available at
+https://github.com/edwgiz/maven-shaded-log4j-transformer[edwgiz/maven-shaded-log4j-transformer]
+and was donated to the Apache Software Foundation by its author.
+
+== Usage
+
+This resource transformer is usually used together with the `ManifestResourceTrasnformer` and `ServicesResourceTransformer` to integrate Log4j 2.x libraries in a shaded jar.
+
+A typical configuration is:
+
+[source,xml]
+----
+<project>
+  [...]
+  <build>
+    <plugins>
+      [...]
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.4.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
+            <version>0.1.0</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      [...]
+    </plugins>
+  </build>
+  [...]
+</project>
+----


### PR DESCRIPTION
It looks like `log4j-transform-maven-shade-plugin-extensions/README.adoc` file was unintentionally removed,
the PR returns it back

@vy can you please confirm and approve?