### PR TITLE
Skip the transformer if log4j-api isn't present

### DIFF
--- a/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
+++ b/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
@@ -205,15 +205,17 @@ public class LocationMojo extends AbstractMojo {
         }
         try {
             if (MIN_SUPPORTED_VERSION.compareTo(log4jApi.getSelectedVersion()) > 0) {
-                throw new MojoExecutionException("Log4j2 API version " + MIN_SUPPORTED_VERSION
-                        + " required. Selected version: " + log4jApi.getSelectedVersion());
+                getLog().error("Log4j2 API version " + MIN_SUPPORTED_VERSION + " required. Selected version: "
+                        + log4jApi.getSelectedVersion());
+                return false;
             }
             // Transitive dependency
             if (!project.getDependencyArtifacts().contains(log4jApi)) {
                 getLog().warn("Log4j2 API should not be a transitive dependency.");
             }
         } catch (OverConstrainedVersionException e) {
-            throw new MojoExecutionException("Can not determine `log4j-api` version.", e);
+            getLog().error("Can not determine `log4j-api` version. " + e.getMessage());
+            return false;
         }
         return true;
     }

--- a/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
+++ b/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
@@ -200,7 +200,7 @@ public class LocationMojo extends AbstractMojo {
         if (artifact.isPresent()) {
             log4jApi = artifact.get();
         } else {
-            getLog().info("Skipping project. Log4j is not being used.");
+            getLog().info("Skipping project. Log4j API is not being used.");
             return false;
         }
         try {


### PR DESCRIPTION
This will exit the plugin with an info message if log4j-api is not present.