### PR TITLE
Document equivalent GradleUp Shadow transformer

### DIFF
--- a/src/site/antora/modules/ROOT/pages/log4j-transform-maven-shade-plugin-extensions.adoc
+++ b/src/site/antora/modules/ROOT/pages/log4j-transform-maven-shade-plugin-extensions.adoc
@@ -35,7 +35,7 @@ and was donated to the Apache Software Foundation by its author.
 [TIP]
 ====
 If you are a Gradle user, you can use the
-https://gradleup.com/shadow/configuration/merging/#merging-log4j2-plugin-cache-files-log4j2pluginsdat[equivalent GradleUp Shadow transformer].
+https://gradleup.com/shadow/configuration/merging/#merging-log4j2-plugin-cache-files-log4j2pluginsdat[equivalent Shadow Gradle Plugin transformer].
 ====
 
 [#log4j-plugin-cache-transformer-usage]

--- a/src/site/antora/modules/ROOT/pages/log4j-transform-maven-shade-plugin-extensions.adoc
+++ b/src/site/antora/modules/ROOT/pages/log4j-transform-maven-shade-plugin-extensions.adoc
@@ -35,7 +35,7 @@ and was donated to the Apache Software Foundation by its author.
 [TIP]
 ====
 If you are a Gradle user, you can use the
-https://gradleup.com/shadow/configuration/merging/#merging-log4j2-plugin-cache-files-log4j2pluginsdat[equivalent Shadow Gradle Plugin transformer].
+https://gradleup.com/shadow/configuration/merging/#merging-log4j2-plugin-cache-files-log4j2plugins-dat[equivalent Shadow Gradle Plugin transformer].
 ====
 
 [#log4j-plugin-cache-transformer-usage]

--- a/src/site/antora/modules/ROOT/pages/log4j-transform-maven-shade-plugin-extensions.adoc
+++ b/src/site/antora/modules/ROOT/pages/log4j-transform-maven-shade-plugin-extensions.adoc
@@ -32,6 +32,12 @@ This transformer was formerly available at
 https://github.com/edwgiz/maven-shaded-log4j-transformer[edwgiz/maven-shaded-log4j-transformer]
 and was donated to the Apache Software Foundation by its author.
 
+[TIP]
+====
+If you are a Gradle user, you can use the
+https://gradleup.com/shadow/configuration/merging/#merging-log4j2-plugin-cache-files-log4j2pluginsdat[equivalent GradleUp Shadow transformer].
+====
+
 [#log4j-plugin-cache-transformer-usage]
 === Usage
 


### PR DESCRIPTION
This adds a link to the GradleUp Shadow component that merges `Log4j2Plugins.dat` descriptors.