### PR TITLE
Migrate deprecated APIs and cleanups

### DIFF
--- a/log4j-converter-config/src/test/java/org/apache/logging/converter/config/internal/v1/AbstractV1ConfigurationParserTest.java
+++ b/log4j-converter-config/src/test/java/org/apache/logging/converter/config/internal/v1/AbstractV1ConfigurationParserTest.java
@@ -27,7 +27,7 @@ import org.apache.logging.converter.config.spi.ConfigurationNode;
 
 public class AbstractV1ConfigurationParserTest extends AbstractConfigurationMapperTest {
 
-    static ConfigurationNode EXAMPLE_V1_CONFIGURATION = newNodeBuilder()
+    static final ConfigurationNode EXAMPLE_V1_CONFIGURATION = newNodeBuilder()
             .setPluginName("Configuration")
             .addChild(newNodeBuilder()
                     .setPluginName("Properties")

--- a/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
+++ b/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
@@ -42,7 +42,6 @@ import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.apache.maven.artifact.versioning.OverConstrainedVersionException;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -102,7 +101,7 @@ public class LocationMojo extends AbstractMojo {
     private int staleMillis;
 
     @Override
-    public void execute() throws MojoExecutionException, MojoFailureException {
+    public void execute() throws MojoExecutionException {
         if ("pom".equals(project.getPackaging())) {
             getLog().info("Skipping project with packaging \"pom\".");
             return;
@@ -192,7 +191,7 @@ public class LocationMojo extends AbstractMojo {
         }
     }
 
-    private boolean validateLog4jVersion() throws MojoExecutionException {
+    private boolean validateLog4jVersion() {
         Optional<Artifact> artifact = project.getArtifacts().stream()
                 .filter(a -> LOG4J_GROUP_ID.equals(a.getGroupId()) && LOG4J_API_ARTIFACT_ID.equals(a.getArtifactId()))
                 .findAny();

--- a/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
+++ b/log4j-transform-maven-plugin/src/main/java/org/apache/logging/log4j/transform/maven/LocationMojo.java
@@ -210,7 +210,7 @@ public class LocationMojo extends AbstractMojo {
                 return false;
             }
             // Transitive dependency
-            if (!project.getDependencyArtifacts().contains(log4jApi)) {
+            if (!project.getArtifacts().contains(log4jApi)) {
                 getLog().warn("Log4j2 API should not be a transitive dependency.");
             }
         } catch (OverConstrainedVersionException e) {

--- a/log4j-transform-maven-shade-plugin-extensions/src/main/java/org/apache/logging/log4j/maven/plugins/shade/transformer/CloseShieldOutputStream.java
+++ b/log4j-transform-maven-shade-plugin-extensions/src/main/java/org/apache/logging/log4j/maven/plugins/shade/transformer/CloseShieldOutputStream.java
@@ -16,7 +16,7 @@
  */
 package org.apache.logging.log4j.maven.plugins.shade.transformer;
 
-import static org.apache.commons.io.output.ClosedOutputStream.CLOSED_OUTPUT_STREAM;
+import static org.apache.commons.io.output.ClosedOutputStream.INSTANCE;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,6 +37,6 @@ final class CloseShieldOutputStream extends ProxyOutputStream {
     @Override
     public void close() throws IOException {
         out.flush();
-        out = CLOSED_OUTPUT_STREAM;
+        out = INSTANCE;
     }
 }

--- a/log4j-transform-maven-shade-plugin-extensions/src/main/java/org/apache/logging/log4j/maven/plugins/shade/transformer/Log4j2PluginCacheFileTransformer.java
+++ b/log4j-transform-maven-shade-plugin-extensions/src/main/java/org/apache/logging/log4j/maven/plugins/shade/transformer/Log4j2PluginCacheFileTransformer.java
@@ -107,7 +107,7 @@ public class Log4j2PluginCacheFileTransformer implements ReproducibleResourceTra
      */
     @Override
     public boolean hasTransformedResource() {
-        return tempFiles.size() > 0;
+        return !tempFiles.isEmpty();
     }
 
     /**

--- a/log4j-weaver/src/main/java/org/apache/logging/log4j/weaver/LocationCacheGenerator.java
+++ b/log4j-weaver/src/main/java/org/apache/logging/log4j/weaver/LocationCacheGenerator.java
@@ -278,7 +278,7 @@ public class LocationCacheGenerator {
      */
     private static class LocationCacheContents {
         private final List<StackTraceElement> locations = new CopyOnWriteArrayList<>();
-        private Set<SupplierLambdaType> lambdas = EnumSet.noneOf(SupplierLambdaType.class);
+        private final Set<SupplierLambdaType> lambdas = EnumSet.noneOf(SupplierLambdaType.class);
 
         public int addLocation(
                 final String internalClassName, final String methodName, final String fileName, final int lineNumber) {

--- a/log4j-weaver/src/main/java/org/apache/logging/log4j/weaver/LocationMethodVisitor.java
+++ b/log4j-weaver/src/main/java/org/apache/logging/log4j/weaver/LocationMethodVisitor.java
@@ -42,8 +42,8 @@ import org.objectweb.asm.commons.GeneratorAdapter;
 public class LocationMethodVisitor extends GeneratorAdapter {
 
     // Programmatically define LAMBDA_METAFACTORY_HANDLE
-    private static Type SUPPLIER_OF_OBJECT_TYPE = Type.getMethodType(OBJECT_TYPE);
-    private static Type SUPPLIER_OF_MESSAGE_TYPE = Type.getMethodType(MESSAGE_TYPE);
+    private static final Type SUPPLIER_OF_OBJECT_TYPE = Type.getMethodType(OBJECT_TYPE);
+    private static final Type SUPPLIER_OF_MESSAGE_TYPE = Type.getMethodType(MESSAGE_TYPE);
     private static final Type LAMBDA_METAFACTORY_TYPE = Type.getType(LambdaMetafactory.class);
     private static final Type METHOD_HANDLE_TYPE = Type.getType(MethodHandle.class);
     private static final Type METHOD_TYPE_TYPE = Type.getType(MethodType.class);

--- a/log4j-weaver/src/main/java/org/apache/logging/log4j/weaver/log4j2/LoggerConversionHandler.java
+++ b/log4j-weaver/src/main/java/org/apache/logging/log4j/weaver/log4j2/LoggerConversionHandler.java
@@ -279,8 +279,8 @@ public class LoggerConversionHandler implements ClassConversionHandler {
             if (types.length == 1) {
                 mv.push((String) null);
             }
-            for (int i = 0; i < vars.length; i++) {
-                mv.loadLocal(vars[i]);
+            for (int var : vars) {
+                mv.loadLocal(var);
             }
             final boolean usesSuppliers = types[types.length - 1].equals(SUPPLIER_ARRAY_TYPE);
             mv.invokeSupplierLambda(


### PR DESCRIPTION
- Replace deprecated `getDependencyArtifacts` with `getArtifacts` in `org.apache.maven.project.MavenProject`.
- Replace deprecated `CLOSED_OUTPUT_STREAM` with `INSTANCE` in `org.apache.commons.io.output.ClosedOutputStream`.